### PR TITLE
Make MarkovChain use Fraction internally 

### DIFF
--- a/simple_markov/lib.py
+++ b/simple_markov/lib.py
@@ -20,11 +20,6 @@ import graphviz as gv
 
 import bisect
 
-class ProbabilityDistributionError(Exception):
-
-    def __init(self, message):
-        self.message = message
-
 class State(object):
     """
     Represents a state in a markov chain.
@@ -41,7 +36,7 @@ class State(object):
         self.prob = { d[0]: Fraction(d[1]) for d in distribution if 0 < float(d[1]) <= 1 }
         self.cum_prob = list(accumulate(v for v in self.prob.values()))
         if self.cum_prob[-1] != 1:
-            raise ProbabilityDistributionError("Transitions from state " + str(label) +
+            raise ValueError("Transitions from state " + str(label) +
                     " do not form a probability distribution")
         self.label = label
 

--- a/simple_markov/lib.py
+++ b/simple_markov/lib.py
@@ -14,11 +14,16 @@ from simple_markov.utils import strongly_connected_components
 # scipy - numpy imports for probability matrix algebra
 from scipy import sparse
 import numpy as np
-
+from fractions import Fraction
 # import graphviz for graph drawing
 import graphviz as gv
 
 import bisect
+
+class ProbabilityDistributionError(Exception):
+
+    def __init(self, message):
+        self.message = message
 
 class State(object):
     """
@@ -33,8 +38,11 @@ class State(object):
         :param distribution: an iterable of state - transition probability pairs
         :param label: the label of the state
         """
-        self.prob = { d[0]: d[1] for d in distribution if 0 < d[1] <= 1 }
+        self.prob = { d[0]: Fraction(d[1]) for d in distribution if 0 < float(d[1]) <= 1 }
         self.cum_prob = list(accumulate(v for v in self.prob.values()))
+        if self.cum_prob[-1] != 1:
+            raise ProbabilityDistributionError("Transitions from state " + str(label) +
+                    " do not form a probability distribution")
         self.label = label
 
     def next_state(self):

--- a/simple_markov/lib.py
+++ b/simple_markov/lib.py
@@ -87,7 +87,12 @@ class MarkovChain(object):
         :param initial_distrib: a map of states to initial probabilities
         :param transition_table: a 2D table containing transition probabilites
         """
-        self.initial_probs = initial_distrib
+
+        self.initial_probs = { k : Fraction(v) for k,v in initial_distrib.items() }
+
+        if sum(self.initial_probs.values()) != 1:
+            raise ValueError("initial_distrib does not form a proper probability "
+                              "distribution")
 
         # map of label-to-state pairs
         self.states = {

--- a/tests/simple_markov_test.py
+++ b/tests/simple_markov_test.py
@@ -62,12 +62,12 @@ class TestComponents(unittest.TestCase):
 
         # initial probability table
         init_probs = {
-            C(5): 0.1,
-            C(7): 0.2,
-            C(1): 0.2,
-            C(10): 0.1,
-            C(6): 0.2,
-            C(4): 0.2
+            C(5): "0.1",
+            C(7): "0.2",
+            C(1): "0.2",
+            C(10): "0.1",
+            C(6): "0.2",
+            C(4): "0.2"
         }
 
         # transition table
@@ -94,9 +94,9 @@ class TestComponents(unittest.TestCase):
         properly for a chain with 3 states, one of which is a sink.
         """
         init_probs = {
-            'A': 0.3,
-            'B': 0.4,
-            'C': 0.3
+            'A': "0.3",
+            'B': "0.4",
+            'C': "0.3"
         }
 
         p_table = {
@@ -118,10 +118,10 @@ class TestComponents(unittest.TestCase):
         """
 
         init_probs = {
-            'A': 0.25,
-            'B': 0.25,
-            'C': 0.25,
-            'D': 0.25
+            'A': "0.25",
+            'B': "0.25",
+            'C': "0.25",
+            'D': "0.25"
         }
 
         p_table = {
@@ -135,3 +135,64 @@ class TestComponents(unittest.TestCase):
         states = tuple(i['states'] for i in comm_classes)
         self.assertTrue({'C', 'D'} in states)
         self.assertTrue({'A', 'B'} in states)
+
+    def test_bad_initial_probs(self):
+        """
+        Tests if a bad initial distribution is caught and an exception
+        is raised.
+        """
+
+        err_string = ("initial_distrib does not form a proper "
+                      "probability distribution")
+        flag = False
+
+        init_probs = {
+                'A' : "0.25",
+                'B' : "0.25",
+                'C' : "0.52",
+                'D' : "0.25"
+	}
+
+        p_table = {
+            'A': [('A', "0.5"), ('B', "0.5")],
+            'B': [('A', "0.2"), ('B', "0.6"), ('C', "0.2")],
+            'C': [('D', "0.5"), ('C', "0.5")],
+            'D': [('C', "0.9"), ('D', "0.1")]
+        }
+
+        try:
+            m = MarkovChain(init_probs, p_table)
+        except ValueError as e:
+            self.assertEqual(e.args[0], err_string)
+            flag = True
+
+        self.assertTrue(flag)
+
+    def test_bad_transitioon_table(self):
+        """
+        Tests if a bad initial distribution is caught and an exception
+        is raised.
+        """
+        err_string = ("Transitions from state D do not form a "
+                      "probability distribution")
+        flag = False
+
+        init_probs = {
+                'A' : "0.25",
+                'B' : "0.25",
+                'C' : "0.25",
+                'D' : "0.25"
+        }
+
+        p_table = {
+            'A': [('A', "0.5"), ('B', "0.5")],
+            'B': [('A', "0.2"), ('B', "0.6"), ('C', "0.2")],
+            'C': [('D', "0.5"), ('C', "0.5")],
+            'D': [('C', "0.9"), ('D', "1.1")]
+        }
+
+        try:
+            m = MarkovChain(init_probs, p_table)
+        except ValueError as e:
+            self.assertEqual(e.args[0], err_string)
+            flag = True

--- a/tests/simple_markov_test.py
+++ b/tests/simple_markov_test.py
@@ -16,10 +16,10 @@ class TestSimulation(unittest.TestCase):
 
         # transition probability table
         p_table = {
-            'A': [('A', 0.5), ('B', 0.5)],
-            'B': [('A', 0.2), ('B', 0.6), ('C', 0.2)],
-            'C': [('D', 0.5), ('C', 0.5)],
-            'D': [('C', 0.9), ('D', 0.1)]
+            'A': [('A', "0.5"), ('B', "0.5")],
+            'B': [('A', "0.2"), ('B', "0.6"), ('C', "0.2")],
+            'C': [('D', "0.5"), ('C', "0.5")],
+            'D': [('C', "0.9"), ('D', "0.1")]
         }
 
         # create the chain
@@ -72,18 +72,18 @@ class TestComponents(unittest.TestCase):
 
         # transition table
         transition_table = {
-            C(5): [(C(7), 0.7), (C(1), 0.1), (C(10), 0.2)],
-            C(1): [(C(7), 0.5), (C(10), 0.5)],
-            C(7): [(C(7), 0.9), (C(5), 0.1)],
-            C(10): [(C(5), 0.3), (C(10), 0.5), (C(4), 0.2)],
-            C(4): [(C(4), 0.5), (C(6), 0.5)],
-            C(6): [(C(4), 1.0)]
+            C(5): [(C(7), "0.7"), (C(1), "0.1"), (C(10), "0.2")],
+            C(1): [(C(7), "0.5"), (C(10), "0.5")],
+            C(7): [(C(7), "0.9"), (C(5), "0.1")],
+            C(10): [(C(5), "0.3"), (C(10), "0.5"), (C(4), "0.2")],
+            C(4): [(C(4), "0.5"), (C(6), "0.5")],
+            C(6): [(C(4), "1.0")]
         }
 
         # these two methods should not fail
         chain = MarkovChain(init_probs, transition_table)
         classes = chain.communication_classes()
-        
+
         # did it find the correct classes though?
         states = tuple(i['states'] for i in classes)
         self.assertTrue({C(4), C(6)} in states)
@@ -100,9 +100,9 @@ class TestComponents(unittest.TestCase):
         }
 
         p_table = {
-            'A': [('A', 0.5), ('B', 0.5)],
-            'B': [('A', 0.8), ('B', 0.1), ('C', 0.1)],
-            'C': [('C', 1.0)]
+            'A': [('A', "0.5"), ('B', "0.5")],
+            'B': [('A', "0.8"), ('B', "0.1"), ('C', "0.1")],
+            'C': [('C', "1.0")]
         }
 
         comm_classes = MarkovChain(init_probs, p_table).communication_classes()
@@ -125,10 +125,10 @@ class TestComponents(unittest.TestCase):
         }
 
         p_table = {
-            'A': [('A', 0.5), ('B', 0.5)],
-            'B': [('A', 0.2), ('B', 0.6), ('C', 0.2)],
-            'C': [('D', 0.5), ('C', 0.5)],
-            'D': [('C', 0.9), ('D', 0.1)]
+            'A': [('A', "0.5"), ('B', "0.5")],
+            'B': [('A', "0.2"), ('B', "0.6"), ('C', "0.2")],
+            'C': [('D', "0.5"), ('C', "0.5")],
+            'D': [('C', "0.9"), ('D', "0.1")]
         }
 
         comm_classes = MarkovChain(init_probs, p_table).communication_classes()


### PR DESCRIPTION
In response to issue #12. This is partial fix since it only checks for errors in the probability distribution of the transitions in each row of the table and not of the initial distribution.
